### PR TITLE
Fix launching games from `/media/sdcard1/`

### DIFF
--- a/main-ui/devices/miyoo_trim_common.py
+++ b/main-ui/devices/miyoo_trim_common.py
@@ -63,7 +63,8 @@ class MiyooTrimCommon():
         #file_path = /mnt/SDCARD/Roms/FAKE08/Alpine Alpaca.p8
         #miyoo maps it to /media/sdcard0/Emu/FAKE08/../../Roms/FAKE08/Alpine Alpaca.p8
         miyoo_app_path = MiyooTrimCommon.convert_game_path_to_miyoo_path(rom_info.rom_file_path, remap_sdcard_path)
-        escaped_path = re.sub(r'([$`"\\])', r'\\\1', miyoo_app_path)        
+        miyoo_app_path = str(Path(miyoo_app_path).resolve())
+        escaped_path = re.sub(r'([$`"\\])', r'\\\1', miyoo_app_path)
         MiyooTrimCommon.write_cmd_to_run(f'''chmod a+x "{launch_path}";{run_prefix}"{launch_path}" "{escaped_path}"''')
         device.fix_sleep_sound_bug()
 


### PR DESCRIPTION
Game launching relied on relative paths to directories that don't exist on the second SD card like:
`/media/sdcard0/Emu/PS/../../``

Resolve paths to fix launching from `/media/sdcard1` as game system folders only exist on the main SD card.

(2nd part)
Fixes: #45 