### PR TITLE
change name scheme for 3:2 anbernic devices - group them by resolutio…

### DIFF
--- a/main-ui/devices/anbernic/anbernic_rg28xx.py
+++ b/main-ui/devices/anbernic/anbernic_rg28xx.py
@@ -19,4 +19,4 @@ class AnbernicRG28xx(AnbernicXXCommon):
         return 480
         
     def screen_rotation(self):
-        return 270
+        return 0

--- a/main-ui/devices/anbernic/anbernic_xx_720_x_480.py
+++ b/main-ui/devices/anbernic/anbernic_xx_720_x_480.py
@@ -3,9 +3,9 @@ import os
 
 
 #/mnt/vendor/ctrl/dmenu_ln
-class AnbernicRG34xxSP(AnbernicXXCommon):
+class Anbernic720x480(AnbernicXXCommon):
     def __init__(self, main_ui_mode):
-        self.device_name = "ANBERNIC_RG34XXSP"
+        self.device_name = "ANBERNIC_RGXX720480"
         super().__init__(main_ui_mode)
                        
     def screen_width(self):

--- a/main-ui/devices/anbernic/anbernic_xx_common.py
+++ b/main-ui/devices/anbernic/anbernic_xx_common.py
@@ -42,10 +42,10 @@ from devices.device_common import DeviceCommon
 #/mnt/vendor/ctrl/dmenu_ln
 class AnbernicXXCommon(DeviceCommon):
     def __init__(self, main_ui_mode): 
-        self.device_name = "ANBERNIC_RG34XXSP"
+        self.device_name = "ANBERNIC_RGXX720480"
         script_dir = Path(__file__).resolve().parent
-        default_cfg_path = script_dir / 'anbernic-rg34xxsp-system.json'
-        system_cfg_path = "/mnt/SDCARD/Saves/anbernic-rg34xxsp-system.json"
+        default_cfg_path = script_dir / 'anbernic-rg-xx-system.json'
+        system_cfg_path = "/mnt/SDCARD/Saves/anbernic-rg-xx-system.json"
         self._load_system_config(system_cfg_path, default_cfg_path)
         self.miyoo_games_file_parser = MiyooGamesFileParser()        
         self.game_utils = MiyooTrimGameSystemUtils()

--- a/main-ui/mainui.py
+++ b/main-ui/mainui.py
@@ -102,9 +102,9 @@ def initialize_device(device, main_ui_mode):
     elif "MIYOO_A30" == device or "SPRUCE_MIYOO_A30" == device:
         from devices.miyoo.a30.miyoo_a30 import MiyooA30
         Device.init(MiyooA30(device, main_ui_mode))
-    elif "ANBERNIC_RG34XXSP" == device:
-        from devices.anbernic.anbernic_rg34xxsp import AnbernicRG34xxSP
-        Device.init(AnbernicRG34xxSP(main_ui_mode))
+    elif "ANBERNIC_RGXX720480" == device:
+        from devices.anbernic.anbernic_xx_720_x_480 import Anbernic720x480
+        Device.init(Anbernic720x480(main_ui_mode))
     elif "ANBERNIC_RG28XX" == device:
         from devices.anbernic.anbernic_rg28xx import AnbernicRG28xx
         Device.init(AnbernicRG28xx(main_ui_mode))


### PR DESCRIPTION
…n as we already do for the 4:3 ones, instead of calling them all 34xxSP


Sibling PR to https://github.com/spruceUI/spruceOS/pull/1604